### PR TITLE
[JENKINS-66316] Prepare Google Health Check for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,4 +46,18 @@
       <version>1.9.5</version>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/main/java/com/google/jenkins/plugins/health/ClassLoaderCheck.java
+++ b/src/main/java/com/google/jenkins/plugins/health/ClassLoaderCheck.java
@@ -15,17 +15,16 @@
  */
 package com.google.jenkins.plugins.health;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import static com.google.common.base.CharMatcher.WHITESPACE;
-import static com.google.common.base.CharMatcher.is;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 
 import hudson.Extension;
 import hudson.PluginWrapper;
@@ -41,9 +40,6 @@ import jenkins.model.Jenkins;
  * loader by using the 'class@plugin_name' notation.
  */
 public class ClassLoaderCheck extends HealthCheck {
-  private static final CharMatcher SEP = WHITESPACE.or(is(','));
-  private static final Splitter SPLITTER =
-      Splitter.on(SEP).trimResults().omitEmptyStrings();
 
   private final Iterable<String> classesToCheck;
   @VisibleForTesting Iterable<String> getClassesToCheck() {
@@ -56,8 +52,16 @@ public class ClassLoaderCheck extends HealthCheck {
    */
   @DataBoundConstructor
   public ClassLoaderCheck(String classesToCheckCsv) {
-    this.classesToCheck = ImmutableList.copyOf(SPLITTER.split(
-        checkNotNull(classesToCheckCsv)));
+    List<String> results = new ArrayList<String>();
+    for (String result : Arrays.asList(checkNotNull(classesToCheckCsv).split("[\\s,]+"))) {
+      if (result != null) {
+        result = result.trim();
+        if (!result.isEmpty()) {
+          results.add(result);
+        }
+      }
+    }
+    this.classesToCheck = Collections.unmodifiableList(results);
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/health/ExecutorCheck.java
+++ b/src/main/java/com/google/jenkins/plugins/health/ExecutorCheck.java
@@ -20,10 +20,6 @@ import java.util.Set;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import static com.google.common.base.CharMatcher.WHITESPACE;
-import static com.google.common.base.CharMatcher.is;
-
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -45,7 +41,6 @@ import jenkins.model.Jenkins;
  * a given minimum number of executors of some given labels.
  */
 public class ExecutorCheck extends HealthCheck {
-  private static final CharMatcher SEP = WHITESPACE.or(is(','));
   private final int minExecutors;
   private final Set<? extends Label> labels;
 


### PR DESCRIPTION
See [JENKINS-66316](https://issues.jenkins.io/browse/JENKINS-66316) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.CharMatcher#WHITESPACE` class, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/CharMatcher.html) but was [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/CharMatcher.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR migrates rom `com.google.common.base.CharMatcher` to code that uses the native functionality provided by the Java Platform.

CC @astroilov